### PR TITLE
Just ignore gift if it's currently not available

### DIFF
--- a/src/app/code/community/Ionoi/Gift/Model/Rule/Validator.php
+++ b/src/app/code/community/Ionoi/Gift/Model/Rule/Validator.php
@@ -152,6 +152,9 @@ class Ionoi_Gift_Model_Rule_Validator extends Mage_Core_Model_Abstract
                                 'rule_id' => $rule->getId()
                             )));
                 // add to quote
+                if (false == $product->isSalable()) {
+                    continue;
+                }
                 $result = $quote->addProduct($product, $rule->getQty());
                 // check result
                 if (is_string($result)) {


### PR DESCRIPTION
If your gift is out of stock, you are not able to fill your cart, when the rule matches. So we need to just skip adding the gift.
